### PR TITLE
Correct multiple recipient encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ console.log(env1.payload)
 // Encrypt and decrypt data for multiple recipients using multiple algorithms
 const env2 = Envelope.wrap('Hello world!', { proto: 'univrse.demo' })
 await env2.encrypt([
-  [appSecret, { alg: 'A256GCM' }],
-  [bobPubKey, { alg: 'ECDH-ES+A128GCM', kid: 'bob' }],
-  [bobPubKey, { alg: 'ECIES-BIE1', kid: 'charlie' }]
+  [appSecret,     { alg: 'A256GCM' }],
+  [bobPubKey,     { alg: 'ECDH-ES+A128GCM', kid: 'bob' }],
+  [charliePubKey, { alg: 'ECIES-BIE1', kid: 'charlie' }]
 ])
 
 const bobEnv = Envelope.fromBuffer(env2.toBuffer())


### PR DESCRIPTION
The multiple recipient example encrypts twice with the bobPubKey. It's a little confusing.